### PR TITLE
Updated html to make site responsive

### DIFF
--- a/community.html
+++ b/community.html
@@ -4,25 +4,39 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <title>Acklen Avenue Church of Christ</title>
-  <link href="styles.css" rel="stylesheet" type="text/css" media="screen">
-  <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
-  <script type="text/javascript" src="js/jquery.cycle.all.js"></script>
-  <script type="text/javascript" src="js/scripts.js"></script>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
+<style>
+.navbar {
+    border-bottom-width: 3px;
+    border-bottom-color: #CC9;
+    border-bottom-style: solid;
+}
+</style>
 </head>
 
 
 <body>
-  <div id="wrapper">
-    <div id="logo"><img src="images/acklen_logo.jpg" width="244" height="87" alt="Acklen Avenue Church of Christ" /></div>
-    <div id="nav">
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="who.html">Who We Are</a></li>
-        <li><a href="community.html">Community Life</a></li>
-        <li><a href="location.html">Visit Us</a></li>
-      </ul>
-    </div>
-    <div id="container_interior">
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js" integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1" crossorigin="anonymous"></script>
+
+<nav class="navbar navbar-expand-md navbar-light">
+  <a class="navbar-brand" style="max-width: 50%;" href="#"><img class="img-fluid" alt="Acklen Logo" src="images/acklen_logo.jpg"></a>
+  <button class="navbar-toggler justify-content-end" type="button" data-toggle="collapse" data-target="#navbarSupportedContent">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse align-self-end" id="navbarSupportedContent">
+    <ul class="navbar-nav w-100 justify-content-end">
+        <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+        <li class="nav-item"><a class="nav-link" href="who.html">Who We Are</a></li>
+        <li class="nav-item active"><a class="nav-link" href="community.html">Community Life</a></li>
+        <li class="nav-item"><a class="nav-link" href="location.html">Location &amp; Service Times</a></li>
+    </ul>
+  </div>
+</nav>
+  <div class="container-fluid p-4">
       <div id="content">
         <h1>Community Life</h1>
         <h2>Ways to Connect:</h2>
@@ -83,28 +97,34 @@
               <a href="http://archive.tennessean.com/article/DN/20131208/NEWS01/312080071/Lipscomb-students-female-prisoners-share-classes-life-lessons">LIFE Program-TN Prison for Women</a></p>
 
             <h2>Pictures</h2>
-            <p> <img src="images/community/01.jpg" /><br/><br/>
-              <img src="images/community/03.jpg" /><br/><br/>
+            <p> <img class="img-fluid" src="images/community/01.jpg" /><br/><br/>
+              <img class="img-fluid" src="images/community/03.jpg" /><br/><br/>
               <br/></p>
       </div>
     </div>
   </div>
-  <div id="footer_wrap">
-    <div id="footer">
-      <div id="footer_icons">
-        <a href="http://www.facebook.com/groups/2344458711/" target="_blank"><img src="images/icon_facebook.gif" alt="Facebook" width="32" height="32" border="0" class="icon_pad" /></a>
-      </div>
-      <div id="footer_nav">
-        <ul>
-          <li><a href="index.html">Home</a></li>
-          <li><a href="who.html">Who We Are</a></li>
-          <li><a href="community.html">Community Life</a></li>
-          <li><a href="location.html">Visit Us</a></li>
-        </ul>
-      </div>
-      <div id="footer_copyright">© 2012 Acklen Avenue Church of Christ <strong><a href="https://www.google.com/maps/place/900+Acklen+Ave,+Nashville,+TN+37203/@36.134273,-86.782359,7885m/data=!3m1!1e3!4m5!3m4!1s0x886466800df13e37:0x44e9a64f3aec173a!8m2!3d36.1342847!4d-86.7824671">900 Acklen Avenue Nashville, TN 37203</a></strong><a href="mailto:info@acklen.org">Contact Us</a></div>
+<footer class="bd-footer text-white" style="background-color: #383322;">
+  <div id="container-fluid">
+        <div class="row p-4">
+        <div class="col-1 d-flex justify-content-center">
+                <a href="http://www.facebook.com/groups/2344458711/" target="_blank"><img src="images/icon_facebook.gif" alt="Facebook" width="32" height="32" border="0" class="icon_pad" /></a>
+        </div>
+        <div class="col-11">
+                 <div class="row">
+                         <div class="col-lg-5 d-flex justify-content-end">
+                         © 2012 Acklen Avenue Church of Christ<br/>
+                        </div>
+                         <div class="col-lg-5 d-flex justify-content-end">
+                         <strong>900 Acklen Avenue Nashville, TN 37203</strong><br/>
+                        </div>
+                         <div class="col-lg-2 d-flex justify-content-end">
+                         <a href="mailto:info@acklen.org">Contact Us</a></p>
+                        </div>
+                </div>
+        </div>
     </div>
-  </div>
+
+</footer>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -4,86 +4,92 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <title>Acklen Avenue Church of Christ</title>
-  <link href="styles.css" rel="stylesheet" type="text/css" media="screen">
-  <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
   <script type="text/javascript" src="js/jquery.cycle.all.js"></script>
   <script type="text/javascript" src="js/jquery.leanModal.min.js"></script>
   <script type="text/javascript" src="js/scripts.js"></script>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
+<style>
+.navbar {
+    border-bottom-width: 3px;
+    border-bottom-color: #CC9;
+    border-bottom-style: solid;
+}
+</style>
 </head>
 
 <body name='la-message' href='#la-message'>
-  <div id="wrapper">
-    <div id="logo"><img src="images/acklen_logo.jpg" width="244" height="87" alt="Acklen Avenue Church of Christ" /></div>
-    <div id="nav">
-      <ul>
-        <li><a href="who.html">Who We Are</a></li>
-        <li><a href="community.html">Community Life</a></li>
-        <li><a href="location.html">Visit Us</a></li>
-      </ul>
-    </div>
-    <div id="container">
-      <div id="slideshow">
-        <ul id="slide_nav">
-          <li id="prev"><a href="#"><img src="images/prev.png" width="45" height="45" /></a></li>
-          <li id="next"><a href="#"><img src="images/next.png" width="45" height="45" /></a></li>
-        </ul>
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js" integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1" crossorigin="anonymous"></script>
+<nav class="navbar navbar-expand-md navbar-light">
+  <a class="navbar-brand" style="max-width: 50%;" href="#"><img class="img-fluid" alt="Acklen Logo" src="images/acklen_logo.jpg"></a>
+  <button class="navbar-toggler justify-content-end" type="button" data-toggle="collapse" data-target="#navbarSupportedContent">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse align-self-end" id="navbarSupportedContent">
+    <ul class="navbar-nav w-100 justify-content-end">
+        <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
+        <li class="nav-item"><a class="nav-link" href="who.html">Who We Are</a></li>
+        <li class="nav-item"><a class="nav-link" href="community.html">Community Life</a></li>
+        <li class="nav-item"><a class="nav-link" href="location.html">Location &amp; Service Times</a></li>
+    </ul>
+  </div>
+</nav>
+    <div class="container-fluid p-2" id="container">
+	<div id="carouselExampleControls" class="carousel slide" data-ride="carousel">
+	  <div class="carousel-inner" role="listbox">
+	    <div class="carousel-item active">
+	      <img class="d-block img-fluid" src="images/1.jpg" >
+	    </div>
+	    <div class="carousel-item">
+	      <img class="d-block img-fluid" src="images/2.jpg" >
+	    </div>
+	    <div class="carousel-item">
+	      <img class="d-block img-fluid" src="images/3.jpg" >
+	    </div>
+	    <div class="carousel-item">
+	      <img class="d-block img-fluid" src="images/4.jpg" >
+	    </div>
+	    <div class="carousel-item">
+	      <img class="d-block img-fluid" src="images/5.jpg" >
+	    </div>
+	  </div>
+	  <a class="carousel-control-prev" href="#carouselExampleControls" role="button" data-slide="prev">
+	    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+	    <span class="sr-only">Previous</span>
+	  </a>
+	  <a class="carousel-control-next" href="#carouselExampleControls" role="button" data-slide="next">
+	    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+	    <span class="sr-only">Next</span>
+	  </a>
+	</div>
 
-        <ul id="slides">
-          <li><img src="images/1.jpg" /></li>
-          <li><img src="images/2.jpg" /></li>
-          <li><img src="images/3.jpg" /></li>
-          <li><img src="images/4.jpg" /></li>
-          <li><img src="images/5.jpg" /></li>
-        </ul>
-      </div>
-    </div>
-
-    <div id="box_wrap">
-      <div id="box1">
-      </div>
-      <div class="box2_3">
-      </div>
-      <div class="box2_3">
-      </div>
-    </div>
 
   </div>
-  <div id="footer_wrap">
-    <div id="footer">
-      <div id="footer_icons">
-        <a href="http://www.facebook.com/groups/2344458711/" target="_blank"><img src="images/icon_facebook.gif" alt="Facebook" width="32" height="32" border="0" class="icon_pad" /></a>
-      </div>
-      <div id="footer_nav">
-        <ul>
-          <li><a href="who.html">Home</a></li>
-          <li><a href="who.html">Who We Are</a></li>
-          <li><a href="community.html">Community Life</a></li>
-
-          <li><a href="location.html">Visit Us</a></li>
-        </ul>
-      </div>
-      <div id="footer_copyright">© 2012 Acklen Avenue Church of Christ <strong><a href="https://www.google.com/maps/place/900+Acklen+Ave,+Nashville,+TN+37203/@36.134273,-86.782359,7885m/data=!3m1!1e3!4m5!3m4!1s0x886466800df13e37:0x44e9a64f3aec173a!8m2!3d36.1342847!4d-86.7824671">900 Acklen Avenue Nashville, TN 37203</a></strong><a href="contact.html">Contact Us</a></div>
+<footer class="bd-footer text-white" style="background-color: #383322;">
+  <div id="container-fluid">
+        <div class="row p-4">
+        <div class="col-1 d-flex justify-content-center">
+                <a href="http://www.facebook.com/groups/2344458711/" target="_blank"><img src="images/icon_facebook.gif" alt="Facebook" width="32" height="32" border="0" class="icon_pad" /></a>
+        </div>
+        <div class="col-11">
+                 <div class="row">
+                         <div class="col-lg-5 d-flex justify-content-end">
+                         © 2012 Acklen Avenue Church of Christ<br/>
+                        </div>
+                         <div class="col-lg-5 d-flex justify-content-end">
+                         <strong>900 Acklen Avenue Nashville, TN 37203</strong><br/>
+                        </div>
+                         <div class="col-lg-2 d-flex justify-content-end">
+                         <a href="mailto:info@acklen.org">Contact Us</a></p>
+                        </div>
+                </div>
+        </div>
     </div>
-  </div>
-  <div id="la-message" class="modal_close" data-year="2017" data-day="01" data-month="01">
-    <h3>Greetings!</h3>
-    <p style="margin-bottom: 5px; margin-top: 5px;">
-      Over the holiday season the Acklen Avenue congregation will have the following schedule changes:<br/>
-      <ul style="margin-left:15px;">
-        <li>
-          We will have church <b>Sunday morning</b> on <b>December 25</b> and <b>January 1</b> however worship is at <b>10 am</b>          and there will be no class.
-        </li>
-        <li>
-          <b>Sunday night</b> bible study on <b>December 25</b> and <b>January 1</b> is canceled.
-        </li>
-        <li>
-          <b>Wednesday night</b> bible study on <b>December 21 and 28</b> is canceled.
-        </li>
-      </ul>
-      <br/> Please come and join us!
-      <br/>
-    </p>
-  </div>
+
+</footer>
 </body>
 
 </html>

--- a/location.html
+++ b/location.html
@@ -4,38 +4,51 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <title>Acklen Avenue Church of Christ</title>
-  <link href="styles.css" rel="stylesheet" type="text/css" media="screen">
-  <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
-  <script type="text/javascript" src="js/jquery.cycle.all.js"></script>
-  <script type="text/javascript" src="js/scripts.js"></script>
-  <script>
-      function wopen(url, name, w, h) {
-        // Fudge factors for window decoration space.
-        // In my tests these work well on all platforms & browsers.
-
-        var win = window.open(url,
-          name,
-          'width=' + w + ', height=' + h + ', ' +
-          'location=no, menubar=no, ' +
-          'status=no, toolbar=no, scrollbars=no, resizable=no');
-        win.resizeTo(w, h);
-        win.focus();
-      }
-  </script>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
+<style>
+.navbar {
+    border-bottom-width: 3px;
+    border-bottom-color: #CC9;
+    border-bottom-style: solid;
+}
+.google-maps {
+   position: relative;
+   padding-bottom: 75%; // This is the aspect ratio
+   height: 0;
+   overflow: hidden;
+}
+.google-maps iframe {
+   position: absolute;
+   top: 0;
+   left: 0;
+   width: 100% !important;
+   height: 100% !important;
+}
+</style>
 </head>
 
 <body>
-  <div id="wrapper">
-    <div id="logo"><img src="images/acklen_logo.jpg" width="244" height="87" alt="Acklen Avenue Church of Christ" /></div>
-    <div id="nav">
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="who.html">Who We Are</a></li>
-        <li><a href="community.html">Community Life</a></li>
-        <li><a href="location.html">Visit Us</a></li>
-      </ul>
-    </div>
-    <div id="container_interior">
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js" integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1" crossorigin="anonymous"></script>
+
+<nav class="navbar navbar-expand-md navbar-light">
+  <a class="navbar-brand" style="max-width: 50%;" href="#"><img class="img-fluid" alt="Acklen Logo" src="images/acklen_logo.jpg"></a>
+  <button class="navbar-toggler justify-content-end" type="button" data-toggle="collapse" data-target="#navbarSupportedContent">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse align-self-end" id="navbarSupportedContent">
+    <ul class="navbar-nav w-100 justify-content-end">
+        <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+        <li class="nav-item"><a class="nav-link" href="who.html">Who We Are</a></li>
+        <li class="nav-item"><a class="nav-link" href="community.html">Community Life</a></li>
+        <li class="nav-item active"><a class="nav-link" href="location.html">Location &amp; Service Times</a></li>
+    </ul>
+  </div>
+</nav>
+  <div class="container-fluid p-4">
       <div id="content">
         <h1>Location &amp; Service Times</h1>
         <h2>Location</h2>
@@ -43,7 +56,9 @@
           of Nashville, Tennessee.</p>
         <p>Our address is:<br /> 900 Acklen Avenue<br /> Nashville, TN 37203</p>
 
+<div class="google-maps">
         <iframe width="640" height="600" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="http://maps.google.com/maps?q=900+Acklen+Avenue+Nashville,+TN+37203-5410&amp;ie=UTF8&amp;hq=&amp;hnear=900+Acklen+Ave,+Nashville,+Tennessee+37203&amp;gl=us&amp;t=h&amp;z=14&amp;vpsrc=0&amp;ll=36.134273,-86.782359&amp;output=embed"></iframe><br /><small><a href="http://maps.google.com/maps?q=900+Acklen+Avenue+Nashville,+TN+37203-5410&amp;ie=UTF8&amp;hq=&amp;hnear=900+Acklen+Ave,+Nashville,+Tennessee+37203&amp;gl=us&amp;t=h&amp;z=14&amp;vpsrc=0&amp;ll=36.134273,-86.782359&amp;source=embed" style="color:#0000FF;text-align:left">View Larger Map</a></small>
+</div>
         <br/><br/>
         <h2>Service Times</h2>
         <h3>Worship</h3>
@@ -91,22 +106,28 @@
       </div>
     </div>
   </div>
-  <div id="footer_wrap">
-    <div id="footer">
-      <div id="footer_icons">
-        <a href="http://www.facebook.com/groups/2344458711/" target="_blank"><img src="images/icon_facebook.gif" alt="Facebook" width="32" height="32" border="0" class="icon_pad" /></a>
-      </div>
-      <div id="footer_nav">
-        <ul>
-          <li><a href="index.html">Home</a></li>
-          <li><a href="who.html">Who We Are</a></li>
-          <li><a href="community.html">Community Life</a>
-            <li><a href="location.html">Visit Us</a></li>
-        </ul>
-      </div>
-      <div id="footer_copyright">© 2012 Acklen Avenue Church of Christ <strong><a href="https://www.google.com/maps/place/900+Acklen+Ave,+Nashville,+TN+37203/@36.134273,-86.782359,7885m/data=!3m1!1e3!4m5!3m4!1s0x886466800df13e37:0x44e9a64f3aec173a!8m2!3d36.1342847!4d-86.7824671">900 Acklen Avenue Nashville, TN 37203</a></strong><a href="mailto:info@acklen.org">Contact Us</a></div>
+<footer class="bd-footer text-white" style="background-color: #383322;">
+  <div id="container-fluid">
+        <div class="row p-4">
+        <div class="col-1 d-flex justify-content-center">
+                <a href="http://www.facebook.com/groups/2344458711/" target="_blank"><img src="images/icon_facebook.gif" alt="Facebook" width="32" height="32" border="0" class="icon_pad" /></a>
+        </div>
+        <div class="col-11">
+                 <div class="row">
+                         <div class="col-lg-5 d-flex justify-content-end">
+                         © 2012 Acklen Avenue Church of Christ<br/>
+                        </div>
+                         <div class="col-lg-5 d-flex justify-content-end">
+                         <strong>900 Acklen Avenue Nashville, TN 37203</strong><br/>
+                        </div>
+                         <div class="col-lg-2 d-flex justify-content-end">
+                         <a href="mailto:info@acklen.org">Contact Us</a></p>
+                        </div>
+                </div>
+        </div>
     </div>
-  </div>
+
+</footer>
 </body>
 
 </html>

--- a/who.html
+++ b/who.html
@@ -2,27 +2,38 @@
 <html>
 
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <title>Acklen Avenue Church of Christ</title>
-  <link href="styles.css" rel="stylesheet" type="text/css" media="screen">
-  <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
-  <script type="text/javascript" src="js/jquery.cycle.all.js"></script>
-  <script type="text/javascript" src="js/scripts.js"></script>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
+<style>
+.navbar {
+    border-bottom-width: 3px;
+    border-bottom-color: #CC9;
+    border-bottom-style: solid;
+}
+</style>
 </head>
 
 <body>
-  <div id="wrapper">
-    <div id="logo"><img src="images/acklen_logo.jpg" width="244" height="87" alt="Acklen Avenue Church of Christ" /></div>
-    <div id="nav">
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="who.html">Who We Are</a></li>
-        <li><a href="community.html">Community Life</a></li>
-        <li><a href="location.html">Visit Us</a></li>
-      </ul>
-    </div>
-    <div id="container_interior">
-      <div id="content">
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js" integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1" crossorigin="anonymous"></script>
+<nav class="navbar navbar-expand-md navbar-light">
+  <a class="navbar-brand" style="max-width: 50%;" href="#"><img class="img-fluid" alt="Acklen Logo" src="images/acklen_logo.jpg"></a>
+  <button class="navbar-toggler justify-content-end" type="button" data-toggle="collapse" data-target="#navbarSupportedContent">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse align-self-end" id="navbarSupportedContent">
+    <ul class="navbar-nav w-100 justify-content-end">
+        <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+        <li class="nav-item active"><a class="nav-link" href="who.html">Who We Are</a></li>
+        <li class="nav-item"><a class="nav-link" href="community.html">Community Life</a></li>
+        <li class="nav-item"><a class="nav-link" href="location.html">Location &amp; Service Times</a></li>
+    </ul>
+  </div>
+</nav>
+  <div class="container-fluid p-4">
         <h1>Who We Are</h1>
         <p>The Acklen Avenue Church of Christ was organized in January 1934. It moved to its present location in 
           1955 after meeting in nearby houses for more than two decades. God has changed the makeup of our 
@@ -75,22 +86,28 @@
       </div>
     </div>
   </div>
-  <div id="footer_wrap">
-    <div id="footer">
-      <div id="footer_icons">
-        <a href="http://www.facebook.com/groups/2344458711/" target="_blank"><img src="images/icon_facebook.gif" alt="Facebook" width="32" height="32" border="0" class="icon_pad" /></a>
-      </div>
-      <div id="footer_nav">
-        <ul>
-          <li><a href="index.html">Home</a></li>
-          <li><a href="who.html">Who We Are</a></li>
-          <li><a href="community.html">Community Life</a></li>
-          <li><a href="location.html">Visit Us</a></li>
-        </ul>
-      </div>
-      <div id="footer_copyright">© 2012 Acklen Avenue Church of Christ <strong><a href="https://www.google.com/maps/place/900+Acklen+Ave,+Nashville,+TN+37203/@36.134273,-86.782359,7885m/data=!3m1!1e3!4m5!3m4!1s0x886466800df13e37:0x44e9a64f3aec173a!8m2!3d36.1342847!4d-86.7824671">900 Acklen Avenue Nashville, TN 37203</a></strong><a href="mailto:info@acklen.org">Contact Us</a></div>
+<footer class="bd-footer text-white" style="background-color: #383322;">
+  <div id="container-fluid">
+        <div class="row p-4">
+        <div class="col-1 d-flex justify-content-center">
+                <a href="http://www.facebook.com/groups/2344458711/" target="_blank"><img src="images/icon_facebook.gif" alt="Facebook" width="32" height="32" border="0" class="icon_pad" /></a>
+        </div>
+        <div class="col-11">
+                 <div class="row">
+                         <div class="col-lg-5 d-flex justify-content-end">
+                         © 2012 Acklen Avenue Church of Christ<br/>
+                        </div>
+                         <div class="col-lg-5 d-flex justify-content-end">
+                         <strong>900 Acklen Avenue Nashville, TN 37203</strong><br/>
+                        </div>
+                         <div class="col-lg-2 d-flex justify-content-end">
+                         <a href="mailto:info@acklen.org">Contact Us</a></p>
+                        </div>
+                </div>
+        </div>
     </div>
-  </div>
+
+</footer>
 </body>
 
 </html>


### PR DESCRIPTION
This code incorporates bootstrap 4 to make the pages responsive while keeping a similar look and feel. I kept the header and footer almost identical. I also updated the few photos, homepage carousel, and google maps iFrame to work well with the responsive html.

Font families and colors are dropped for defaults. Based on Bob's input yesterday, they all need to be reworked because they were not ADA compliant. This fork uses default font families and styles from bootstrap.

This change removes the current css from the html code, but I left the file orphaned for reference on font families and colors if we want to incorporate them back in later.